### PR TITLE
Add Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: rust
+
+cache: cargo
+
 rust:
   - stable
   - beta
   - nightly
+    
+os:
+  - linux
+
+notifications:
+  email: false


### PR DESCRIPTION
I highly suggest using Travis to test PRs.

https://docs.travis-ci.com/user/languages/rust/
https://travis-ci.org/profile/chr4

I have chosen the `stable` channel because this builds and runs fine on stable.
Others can be added (or can replace stable) if desired.

In the event that you are running non-stable via `rustup` you can test stable builds with `cargo +stable build` or `rustup run stable cargo build`.